### PR TITLE
Remove the dependency on `tensorflow.experimental.numpy` and support negative indices for `take` and `take_along_axis`

### DIFF
--- a/keras/src/backend/tensorflow/linalg.py
+++ b/keras/src/backend/tensorflow/linalg.py
@@ -1,5 +1,4 @@
 import tensorflow as tf
-from tensorflow.experimental import numpy as tfnp
 
 from keras.src.backend import config
 from keras.src.backend import standardize_dtype
@@ -36,6 +35,8 @@ def lu_factor(a):
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
+    from keras.src.backend.tensorflow.numpy import moveaxis
+
     x = convert_to_tensor(x)
     x_shape = x.shape
     ndim = x_shape.rank
@@ -129,7 +130,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 keepdims=keepdims,
             )
         elif ord in ("nuc", 2, -2):
-            x = tfnp.moveaxis(x, axis, (-2, -1))
+            x = moveaxis(x, axis, (-2, -1))
             if ord == -2:
                 x = tf.math.reduce_min(
                     tf.linalg.svd(x, compute_uv=False), axis=-1

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -1,5 +1,4 @@
 import tensorflow as tf
-from tensorflow.experimental import numpy as tfnp
 
 from keras.src.backend import config
 from keras.src.backend import standardize_dtype
@@ -260,6 +259,8 @@ def solve(a, b):
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
+    from keras.src.backend.tensorflow.numpy import moveaxis
+
     x = convert_to_tensor(x)
     x_shape = x.shape
     ndim = x_shape.rank
@@ -328,7 +329,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 keepdims=keepdims,
             )
         else:
-            x = tfnp.moveaxis(x, axis, (-2, -1))
+            x = moveaxis(x, axis, (-2, -1))
             if ord == -2:
                 x = tf.math.reduce_min(
                     tf.linalg.svd(x, compute_uv=False), axis=-1

--- a/keras/src/backend/tensorflow/random.py
+++ b/keras/src/backend/tensorflow/random.py
@@ -1,5 +1,4 @@
 import tensorflow as tf
-from tensorflow.experimental import numpy as tfnp
 
 from keras.src.backend.common import standardize_dtype
 from keras.src.backend.config import floatx
@@ -87,12 +86,14 @@ def dropout(inputs, rate, noise_shape=None, seed=None):
 
 
 def shuffle(x, axis=0, seed=None):
+    from keras.src.backend.tensorflow.numpy import swapaxes
+
     seed = tf_draw_seed(seed)
     if axis == 0:
         return tf.random.experimental.stateless_shuffle(x, seed=seed)
-    x = tfnp.swapaxes(x, axis1=0, axis2=axis)
+    x = swapaxes(x, axis1=0, axis2=axis)
     x = tf.random.experimental.stateless_shuffle(x, seed=seed)
-    x = tfnp.swapaxes(x, axis1=0, axis2=axis)
+    x = swapaxes(x, axis1=0, axis2=axis)
     return x
 
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -5266,14 +5266,18 @@ def trace(x, offset=0, axis1=0, axis2=1):
 
 
 class Tri(Operation):
-    def call(self, N, M=None, k=0, dtype=None):
-        return backend.numpy.tri(N, M=M, k=k, dtype=dtype)
+    def __init__(self, k=0, dtype=None):
+        super().__init__()
+        self.k = k
+        self.dtype = dtype or backend.floatx()
 
-    def compute_output_spec(self, N, M=None, k=0, dtype=None):
+    def call(self, N, M=None):
+        return backend.numpy.tri(N=N, M=M, k=self.k, dtype=self.dtype)
+
+    def compute_output_spec(self, N, M=None):
         if M is None:
             M = N
-        dtype = dtype or backend.floatx()
-        return KerasTensor((N, M), dtype=dtype)
+        return KerasTensor((N, M), dtype=self.dtype)
 
 
 @keras_export(["keras.ops.tri", "keras.ops.numpy.tri"])
@@ -6021,14 +6025,18 @@ def ones(shape, dtype=None):
 
 
 class Eye(Operation):
-    def call(self, N, M=None, k=0, dtype=None):
-        return backend.numpy.eye(N, M=M, k=k, dtype=dtype)
+    def __init__(self, k=0, dtype=None):
+        super().__init__()
+        self.k = k
+        self.dtype = dtype or backend.floatx()
 
-    def compute_output_spec(self, N, M=None, k=0, dtype=None):
+    def call(self, N, M=None):
+        return backend.numpy.eye(N, M=M, k=self.k, dtype=self.dtype)
+
+    def compute_output_spec(self, N, M=None):
         if M is None:
             M = N
-        dtype = dtype or backend.floatx()
-        return KerasTensor((N, M), dtype=dtype)
+        return KerasTensor((N, M), dtype=self.dtype)
 
 
 @keras_export(["keras.ops.eye", "keras.ops.numpy.eye"])


### PR DESCRIPTION
Recreated from original PR: https://github.com/keras-team/keras/pull/19556

Mainly, this PR removes the dependency on `tfnp`.

I've tried to eliminate the usage of `tf.cond` in some important ops such as `take_along_axis`.
Additionally, support for negative indices has been added and tested for both `take` and `take_along_axis`, especially for tensorflow and torch backends.

EDITED:
- Add `__init__` both for `Tri` and `Eye` for consistency with convention of `k` and `dtype`